### PR TITLE
[iOS] 할 일 카드 추가 기능 구현

### DIFF
--- a/iOS/ToDo/ToDo.xcodeproj/project.pbxproj
+++ b/iOS/ToDo/ToDo.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		78143A80243F4E0F000DE8CD /* ColumnInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78143A7F243F4E0F000DE8CD /* ColumnInformation.swift */; };
 		78143A84243F4F5E000DE8CD /* ColumnInformationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78143A83243F4F5E000DE8CD /* ColumnInformationManager.swift */; };
 		781C2AC6244229B800EED845 /* EditorTextFieldDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 781C2AC5244229B800EED845 /* EditorTextFieldDelegate.swift */; };
+		781C2AC82442300500EED845 /* EditorTextViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 781C2AC72442300500EED845 /* EditorTextViewDelegate.swift */; };
 		783C61D6243C7226005E6097 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 783C61D5243C7226005E6097 /* AppDelegate.swift */; };
 		783C61D8243C7226005E6097 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 783C61D7243C7226005E6097 /* SceneDelegate.swift */; };
 		783C61DD243C7226005E6097 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 783C61DB243C7226005E6097 /* Main.storyboard */; };
@@ -30,6 +31,7 @@
 		78143A7F243F4E0F000DE8CD /* ColumnInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColumnInformation.swift; sourceTree = "<group>"; };
 		78143A83243F4F5E000DE8CD /* ColumnInformationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColumnInformationManager.swift; sourceTree = "<group>"; };
 		781C2AC5244229B800EED845 /* EditorTextFieldDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorTextFieldDelegate.swift; sourceTree = "<group>"; };
+		781C2AC72442300500EED845 /* EditorTextViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorTextViewDelegate.swift; sourceTree = "<group>"; };
 		783C61D2243C7226005E6097 /* ToDo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ToDo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		783C61D5243C7226005E6097 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		783C61D7243C7226005E6097 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -120,6 +122,7 @@
 				786721C2243CAEF9003441CC /* ListTableViewDataSource.swift */,
 				786721C8243CE4B4003441CC /* EditorViewController.swift */,
 				781C2AC5244229B800EED845 /* EditorTextFieldDelegate.swift */,
+				781C2AC72442300500EED845 /* EditorTextViewDelegate.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -199,6 +202,7 @@
 				78143A84243F4F5E000DE8CD /* ColumnInformationManager.swift in Sources */,
 				786721C3243CAEF9003441CC /* ListTableViewDataSource.swift in Sources */,
 				781C2AC6244229B800EED845 /* EditorTextFieldDelegate.swift in Sources */,
+				781C2AC82442300500EED845 /* EditorTextViewDelegate.swift in Sources */,
 				786721BB243CAC06003441CC /* MainViewController.swift in Sources */,
 				783C61D6243C7226005E6097 /* AppDelegate.swift in Sources */,
 				78A65F0A243DEA670011D7B2 /* TaskInformationManager.swift in Sources */,

--- a/iOS/ToDo/ToDo.xcodeproj/project.pbxproj
+++ b/iOS/ToDo/ToDo.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		78143A80243F4E0F000DE8CD /* ColumnInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78143A7F243F4E0F000DE8CD /* ColumnInformation.swift */; };
 		78143A84243F4F5E000DE8CD /* ColumnInformationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78143A83243F4F5E000DE8CD /* ColumnInformationManager.swift */; };
+		781C2AC6244229B800EED845 /* EditorTextFieldDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 781C2AC5244229B800EED845 /* EditorTextFieldDelegate.swift */; };
 		783C61D6243C7226005E6097 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 783C61D5243C7226005E6097 /* AppDelegate.swift */; };
 		783C61D8243C7226005E6097 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 783C61D7243C7226005E6097 /* SceneDelegate.swift */; };
 		783C61DD243C7226005E6097 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 783C61DB243C7226005E6097 /* Main.storyboard */; };
@@ -28,6 +29,7 @@
 /* Begin PBXFileReference section */
 		78143A7F243F4E0F000DE8CD /* ColumnInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColumnInformation.swift; sourceTree = "<group>"; };
 		78143A83243F4F5E000DE8CD /* ColumnInformationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColumnInformationManager.swift; sourceTree = "<group>"; };
+		781C2AC5244229B800EED845 /* EditorTextFieldDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorTextFieldDelegate.swift; sourceTree = "<group>"; };
 		783C61D2243C7226005E6097 /* ToDo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ToDo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		783C61D5243C7226005E6097 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		783C61D7243C7226005E6097 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -117,6 +119,7 @@
 				786721BC243CAC2C003441CC /* ListViewController.swift */,
 				786721C2243CAEF9003441CC /* ListTableViewDataSource.swift */,
 				786721C8243CE4B4003441CC /* EditorViewController.swift */,
+				781C2AC5244229B800EED845 /* EditorTextFieldDelegate.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -195,6 +198,7 @@
 			files = (
 				78143A84243F4F5E000DE8CD /* ColumnInformationManager.swift in Sources */,
 				786721C3243CAEF9003441CC /* ListTableViewDataSource.swift in Sources */,
+				781C2AC6244229B800EED845 /* EditorTextFieldDelegate.swift in Sources */,
 				786721BB243CAC06003441CC /* MainViewController.swift in Sources */,
 				783C61D6243C7226005E6097 /* AppDelegate.swift in Sources */,
 				78A65F0A243DEA670011D7B2 /* TaskInformationManager.swift in Sources */,

--- a/iOS/ToDo/ToDo/Base.lproj/Main.storyboard
+++ b/iOS/ToDo/ToDo/Base.lproj/Main.storyboard
@@ -86,11 +86,11 @@
                                 </connections>
                             </button>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Title" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="x0F-Os-uoM">
-                                <rect key="frame" x="100" y="100" width="72" height="42"/>
+                                <rect key="frame" x="100" y="100" width="498.5" height="42"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="35"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="Content" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="Cjn-WR-tiv">
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="Cjn-WR-tiv">
                                 <rect key="frame" x="100" y="150" width="498.5" height="556"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
@@ -102,6 +102,7 @@
                         <constraints>
                             <constraint firstItem="Cjn-WR-tiv" firstAttribute="leading" secondItem="VhW-ft-gFL" secondAttribute="leading" constant="100" id="0M0-rc-Bfy"/>
                             <constraint firstItem="zSm-Tu-3ET" firstAttribute="top" secondItem="VhW-ft-gFL" secondAttribute="top" constant="24" id="8Cv-5q-JAr"/>
+                            <constraint firstItem="x0F-Os-uoM" firstAttribute="width" secondItem="XVf-CA-j0e" secondAttribute="width" multiplier="0.7" id="KMM-m4-w7a"/>
                             <constraint firstItem="Cjn-WR-tiv" firstAttribute="height" secondItem="XVf-CA-j0e" secondAttribute="height" multiplier="0.7" id="NdW-tT-mnE"/>
                             <constraint firstItem="zSm-Tu-3ET" firstAttribute="leading" secondItem="VhW-ft-gFL" secondAttribute="leading" constant="24" id="Oem-3i-OnJ"/>
                             <constraint firstItem="5mx-tM-h88" firstAttribute="top" secondItem="VhW-ft-gFL" secondAttribute="top" constant="24" id="Prp-Z6-NuY"/>
@@ -127,7 +128,7 @@
             <objects>
                 <viewController id="zTG-Qc-OVr" customClass="ListViewController" customModule="ToDo" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="R2h-8b-o54">
-                        <rect key="frame" x="0.0" y="0.0" width="385" height="764"/>
+                        <rect key="frame" x="0.0" y="0.0" width="384.5" height="764"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bsN-rh-2b4">

--- a/iOS/ToDo/ToDo/Base.lproj/Main.storyboard
+++ b/iOS/ToDo/ToDo/Base.lproj/Main.storyboard
@@ -78,9 +78,11 @@
                                     <action selector="touchUpCancelButton:" destination="s3w-fT-Y6j" eventType="touchUpInside" id="uro-qJ-apP"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5mx-tM-h88">
+                            <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5mx-tM-h88">
                                 <rect key="frame" x="625" y="24" width="63" height="30"/>
-                                <state key="normal" title="Add Task"/>
+                                <state key="normal" title="Add Task">
+                                    <color key="titleColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </state>
                                 <connections>
                                     <action selector="touchUpAddTaskButton:" destination="s3w-fT-Y6j" eventType="touchUpInside" id="6UP-N9-dfb"/>
                                 </connections>
@@ -89,6 +91,9 @@
                                 <rect key="frame" x="100" y="100" width="498.5" height="42"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="35"/>
                                 <textInputTraits key="textInputTraits"/>
+                                <connections>
+                                    <action selector="textFieldEditingDidChange:" destination="s3w-fT-Y6j" eventType="editingChanged" id="YOa-yG-04N"/>
+                                </connections>
                             </textField>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="Cjn-WR-tiv">
                                 <rect key="frame" x="100" y="150" width="498.5" height="556"/>
@@ -115,6 +120,7 @@
                         <viewLayoutGuide key="safeArea" id="VhW-ft-gFL"/>
                     </view>
                     <connections>
+                        <outlet property="addTaskButton" destination="5mx-tM-h88" id="TzG-93-C8d"/>
                         <outlet property="contentTextView" destination="Cjn-WR-tiv" id="xAR-8Z-ykO"/>
                         <outlet property="titleTextField" destination="x0F-Os-uoM" id="FJ7-oz-Z4Z"/>
                     </connections>

--- a/iOS/ToDo/ToDo/Constants.swift
+++ b/iOS/ToDo/ToDo/Constants.swift
@@ -13,3 +13,6 @@ let inProgressSegue = "inProgressSegue"
 let doneSegue = "doneSegue"
 let editorSegue = "editorSegue"
 let listTableViewCell = "listTableViewCell"
+
+let addTaskNotification = Notification.Name("addTaskNotification")
+let addTaskInfoKey = "column"

--- a/iOS/ToDo/ToDo/Controllers/EditorTextFieldDelegate.swift
+++ b/iOS/ToDo/ToDo/Controllers/EditorTextFieldDelegate.swift
@@ -17,6 +17,8 @@ class EditorTextFieldDelegate: NSObject, UITextFieldDelegate {
         if let count = titleTextField?.text?.count, count == 0 { return false }
         titleTextField?.resignFirstResponder()
         contentTextView?.becomeFirstResponder()
+        contentTextView?.text = ""
+        contentTextView?.textColor = .black
         return true
     }
     

--- a/iOS/ToDo/ToDo/Controllers/EditorTextFieldDelegate.swift
+++ b/iOS/ToDo/ToDo/Controllers/EditorTextFieldDelegate.swift
@@ -1,0 +1,23 @@
+//
+//  EditorTextFieldDelegate.swift
+//  ToDo
+//
+//  Created by jinie on 2020/04/12.
+//  Copyright © 2020 jinie. All rights reserved.
+//
+
+import UIKit
+
+class EditorTextFieldDelegate: NSObject, UITextFieldDelegate {
+    
+    var titleTextField: UITextField?
+    var contentTextView: UITextView?
+
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        if let count = titleTextField?.text?.count, count == 0 { return false }
+        titleTextField?.resignFirstResponder()
+        contentTextView?.becomeFirstResponder()
+        return true
+    }
+    
+}

--- a/iOS/ToDo/ToDo/Controllers/EditorTextViewDelegate.swift
+++ b/iOS/ToDo/ToDo/Controllers/EditorTextViewDelegate.swift
@@ -1,0 +1,29 @@
+//
+//  EditorTextViewDelegate.swift
+//  ToDo
+//
+//  Created by jinie on 2020/04/12.
+//  Copyright © 2020 jinie. All rights reserved.
+//
+
+import UIKit
+
+class EditorTextViewDelegate: NSObject, UITextViewDelegate {
+    
+    var contentTextView: UITextView?
+    
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        if contentTextView?.textColor == .lightGray {
+            contentTextView?.text = ""
+            contentTextView?.textColor = .black
+        }
+    }
+    
+    func textViewDidEndEditing(_ textView: UITextView) {
+        if let contentTextView = contentTextView, contentTextView.text.isEmpty {
+            contentTextView.text = "Content"
+            contentTextView.textColor = .lightGray
+        }
+    }
+    
+}

--- a/iOS/ToDo/ToDo/Controllers/EditorTextViewDelegate.swift
+++ b/iOS/ToDo/ToDo/Controllers/EditorTextViewDelegate.swift
@@ -26,4 +26,10 @@ class EditorTextViewDelegate: NSObject, UITextViewDelegate {
         }
     }
     
+    func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        guard let textViewText = textView.text else { return true }
+        let count = textViewText.count + text.count
+        return count <= 500
+    }
+    
 }

--- a/iOS/ToDo/ToDo/Controllers/EditorViewController.swift
+++ b/iOS/ToDo/ToDo/Controllers/EditorViewController.swift
@@ -19,9 +19,20 @@ class EditorViewController: UIViewController {
     @IBAction func touchUpCancelButton(_ sender: UIButton) {
         self.dismiss(animated: true, completion: nil)
     }
+    
+    private let textFieldDelegate = EditorTextFieldDelegate()
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        configureTitleTextField()
+    }
+    
+    func configureTitleTextField() {
+        titleTextField.delegate = textFieldDelegate
+        textFieldDelegate.titleTextField = titleTextField
+        textFieldDelegate.contentTextView = contentTextView
+        titleTextField.becomeFirstResponder()
     }
 
 }

--- a/iOS/ToDo/ToDo/Controllers/EditorViewController.swift
+++ b/iOS/ToDo/ToDo/Controllers/EditorViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 
 class EditorViewController: UIViewController {
 
+    @IBOutlet weak var addTaskButton: UIButton!
     @IBOutlet weak var titleTextField: UITextField!
     @IBOutlet weak var contentTextView: UITextView!
     
@@ -18,6 +19,16 @@ class EditorViewController: UIViewController {
     }
     @IBAction func touchUpCancelButton(_ sender: UIButton) {
         self.dismiss(animated: true, completion: nil)
+    }
+    
+    @IBAction func textFieldEditingDidChange(_ sender: UITextField) {
+        if let text = titleTextField.text, !text.isEmpty {
+            addTaskButton.isEnabled = true
+            addTaskButton.setTitleColor(.systemBlue, for: .normal)
+        } else {
+            addTaskButton.isEnabled = false
+            addTaskButton.setTitleColor(.darkGray, for: .normal)
+        }
     }
     
     private let textFieldDelegate = EditorTextFieldDelegate()

--- a/iOS/ToDo/ToDo/Controllers/EditorViewController.swift
+++ b/iOS/ToDo/ToDo/Controllers/EditorViewController.swift
@@ -21,11 +21,12 @@ class EditorViewController: UIViewController {
     }
     
     private let textFieldDelegate = EditorTextFieldDelegate()
+    private let textViewDelegate = EditorTextViewDelegate()
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        
         configureTitleTextField()
+        configureContentTextView()
     }
     
     func configureTitleTextField() {
@@ -33,6 +34,13 @@ class EditorViewController: UIViewController {
         textFieldDelegate.titleTextField = titleTextField
         textFieldDelegate.contentTextView = contentTextView
         titleTextField.becomeFirstResponder()
+    }
+    
+    func configureContentTextView() {
+        contentTextView.delegate = textViewDelegate
+        textViewDelegate.contentTextView = contentTextView
+        contentTextView.text = "Content"
+        contentTextView.textColor = .lightGray
     }
 
 }

--- a/iOS/ToDo/ToDo/Controllers/EditorViewController.swift
+++ b/iOS/ToDo/ToDo/Controllers/EditorViewController.swift
@@ -14,9 +14,23 @@ class EditorViewController: UIViewController {
     @IBOutlet weak var titleTextField: UITextField!
     @IBOutlet weak var contentTextView: UITextView!
     
+    let taskInformationManager = TaskInformationManager()
+    var column: Column?
+    
     @IBAction func touchUpAddTaskButton(_ sender: UIButton) {
-        self.dismiss(animated: true, completion: nil)
+        guard let column = column else { return }
+        guard let content = titleTextField.text else { return }
+        taskInformationManager.addTask(column: column, content: content) {
+            DispatchQueue.main.async {
+                let columnInfo: [String : Column] = [addTaskInfoKey: column]
+                NotificationCenter.default.post(name: addTaskNotification,
+                                                object: nil,
+                                                userInfo: columnInfo)
+                self.dismiss(animated: true, completion: nil)
+            }
+        }
     }
+    
     @IBAction func touchUpCancelButton(_ sender: UIButton) {
         self.dismiss(animated: true, completion: nil)
     }

--- a/iOS/ToDo/ToDo/Controllers/ListViewController.swift
+++ b/iOS/ToDo/ToDo/Controllers/ListViewController.swift
@@ -24,7 +24,6 @@ class ListViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
         configureHeader()
         configureTableView()
         request()

--- a/iOS/ToDo/ToDo/Controllers/ListViewController.swift
+++ b/iOS/ToDo/ToDo/Controllers/ListViewController.swift
@@ -15,7 +15,7 @@ class ListViewController: UIViewController {
     @IBOutlet weak var tableView: UITableView!
     
     @IBAction func touchUpAddButton(_ sender: UIButton) {
-        self.parent?.performSegue(withIdentifier: editorSegue, sender: nil)
+        self.parent?.performSegue(withIdentifier: editorSegue, sender: column)
     }
     
     private var tableViewDataSource = ListTableViewDataSource()
@@ -27,6 +27,10 @@ class ListViewController: UIViewController {
         configureHeader()
         configureTableView()
         request()
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(renewList),
+                                               name: addTaskNotification,
+                                               object: nil)
     }
     
     func configureHeader() {
@@ -47,6 +51,17 @@ class ListViewController: UIViewController {
             DispatchQueue.main.async {
                 self.tableView.reloadData()
                 self.badgeLabel.text = String(self.tableViewDataSource.tasksCount())
+            }
+        }
+    }
+    
+    @objc func renewList(_ notification: Notification) {
+        guard let userInfo = notification.userInfo else { return }
+        let columnInfo = userInfo[addTaskInfoKey] as! Column
+        guard columnInfo == column else { return }
+        tableViewDataSource.request(column: columnInfo) {
+            DispatchQueue.main.async {
+                self.tableView.reloadData()
             }
         }
     }

--- a/iOS/ToDo/ToDo/Controllers/MainViewController.swift
+++ b/iOS/ToDo/ToDo/Controllers/MainViewController.swift
@@ -21,6 +21,10 @@ class MainViewController: UIViewController {
             listViewController.column = .inProgress
         } else if segue.identifier == doneSegue, let listViewController = segue.destination as? ListViewController {
             listViewController.column = .done
+        } else if segue.identifier == editorSegue, let editorViewController = segue.destination as? EditorViewController {
+            if let column = sender as? Column {
+                editorViewController.column = column
+            }
         }
     }
 

--- a/iOS/ToDo/ToDo/Controllers/MainViewController.swift
+++ b/iOS/ToDo/ToDo/Controllers/MainViewController.swift
@@ -10,8 +10,6 @@ import UIKit
 
 class MainViewController: UIViewController {
     
-    let columnInformationManager = ColumnInformationManager()
-    
     override func viewDidLoad() {
         super.viewDidLoad()
     }

--- a/iOS/ToDo/ToDo/Models/ColumnInformation.swift
+++ b/iOS/ToDo/ToDo/Models/ColumnInformation.swift
@@ -21,11 +21,11 @@ struct Columns: Codable {
     
 }
 
-enum Column: String, CustomStringConvertible {
+enum Column: Int, CustomStringConvertible {
 
-    case toDo = "해야할일"
-    case inProgress = "하는중"
-    case done = "다했어"
+    case toDo = 1
+    case inProgress = 2
+    case done = 3
     
     var description: String {
         return "\(self.rawValue)"

--- a/iOS/ToDo/ToDo/Models/TaskInformation.swift
+++ b/iOS/ToDo/ToDo/Models/TaskInformation.swift
@@ -31,14 +31,16 @@ struct Task: Codable {
     let content: String
     let createdDate: String
     let updatedDate: String
-    let userId: String
+    let user: String
+    let deleted: Bool
     
     enum CodingKeys: String, CodingKey {
         case identifier = "id"
         case content
         case createdDate = "createdAt"
         case updatedDate = "updatedAt"
-        case userId
+        case user
+        case deleted
     }
     
 }

--- a/iOS/ToDo/ToDo/Models/TaskInformationManager.swift
+++ b/iOS/ToDo/ToDo/Models/TaskInformationManager.swift
@@ -14,9 +14,7 @@ class TaskInformationManager {
     var tasksCount: Int?
     
     func request(column: Column, _ completion: @escaping () -> ()) {
-        guard let encoded = "\(column)".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else { return }
-        let urlString = "http://15.165.223.140:8080/api/notes/column?columnName=\(encoded)"
-        guard let url = URL(string: urlString) else { return }
+        guard let url = URL(string: "http://15.165.223.140:8080/api/notes/category?categoryId=\(column)") else { return }
         let request = URLRequest(url: url)
         let session = URLSession(configuration: .default)
         let dataTask = session.dataTask(with: request) { (data, response, error) in
@@ -25,6 +23,26 @@ class TaskInformationManager {
             guard let responseData = try? decoder.decode(TaskInformation.self, from: data) else { return }
             self.tasks = responseData.contents.tasks
             self.tasksCount = responseData.contents.tasks.count
+            completion()
+        }
+        dataTask.resume()
+    }
+    
+    func addTask(column: Column, content: String, _ completion: @escaping () -> ()) {
+        guard let url = URL(string: "http://15.165.223.140:8080/api/notes") else { return }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        let body = """
+            {
+                "categoryId": \(column),
+                "content": "\(content)",
+                "user": "jinie"
+            }
+        """.data(using: .utf8)
+        request.httpBody = body
+        let session = URLSession(configuration: .default)
+        let dataTask = session.dataTask(with: request) { (data, response, error) in
             completion()
         }
         dataTask.resume()


### PR DESCRIPTION
- 리스트의 추가 버튼을 탭하여 에디터 화면으로 전환할 시 리스트의 카테고리를 전달하여 새 카드가 해당 리스트에 추가되도록 구현하였습니다.
- 입력한 내용을 POST 요청으로 서버에 전달한 후 Notification을 발송하여 해당 리스트가 데이터를 갱신하도록 구현하였습니다.